### PR TITLE
fix: 음악 중복 재생 오류

### DIFF
--- a/core/voice_client/TTS.py
+++ b/core/voice_client/TTS.py
@@ -8,16 +8,20 @@ import utils.Logs as logs
 
 class TTS:
 
-    def __init__(self, bot, voice_state):
+    def __init__(self, bot):
         self.bot = bot
-        self.voice_state = voice_state
+        self.message_queue = defaultdict(list)
         self.is_cat = defaultdict(bool)
         self.file_path = "./data"
+
+    def cleanup_tts(self, guild_id):
+        if self.message_queue.get(guild_id):
+            del self.message_queue[guild_id]
 
     async def read_message_coroutine(self, guild, voice_client):
         message = None
         try:
-            message = self.voice_state[guild.id].message_queue.pop(0)
+            message = self.message_queue[guild.id].pop(0)
 
             file = f"{guild.id}.mp3"
             result = self.synthesize_text(file, message)


### PR DESCRIPTION
## 음악 중복 재생 오류

1. 플레이리스트를 추가할 경우, 음악 검색 과정에서 긴 시간이 소요되는데 이때 Loop가 멈춤.
2. Loop가 멈춘 상태에서 모든 작업이 종료되고 다시 Loop가 시작되면 밀렸던 Loop 횟수만큼 다시 작동함.
3. 이럴 경우, 플레이리스트에 있는 음악을 동시에 재생명령이 들어가서 중복재생으로 오류가 발생함.
4. Loop 작동을 1초 만큼 반복주기가 차이날 때에만 작동하도록 수정함.

## 음악 재생 상태 기록 제거

1. 정확히는 VoiceClient의 voice_state를 삭제하고, Music.current (현재 재생중인 곡 정보)를 통해 음악 재생 유무를 판단함.